### PR TITLE
Add support for python3.4 and python3.5

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,8 @@
+python-pqueue (0.1.4) unstable; urgency=midium
+
+  * Added support to python 3.4 and python 3.5
+
+
 python-pqueue (0.1.3) unstable; urgency=medium
 
   * Added constructor parameter to use alternative directory instead of /tmp

--- a/pqueue/__init__.py
+++ b/pqueue/__init__.py
@@ -1,6 +1,6 @@
 __author__ = 'G. B. Versiani'
 __license__ = 'BSD'
-__version__ = '0.1.3'
+__version__ = '0.1.4'
 
 import sys
 if sys.version_info < (3, 0):

--- a/pqueue/pqueue.py
+++ b/pqueue/pqueue.py
@@ -103,13 +103,13 @@ class Queue(SyncQ):
             self._saveinfo()
             self.update_info = False
 
-    def _openchunk(self, number, mode='r'):
+    def _openchunk(self, number, mode='rb'):
         return open(self._qfile(number), mode)
 
     def _loadinfo(self):
         infopath = self._infopath()
         if os.path.exists(infopath):
-            with open(infopath) as f:
+            with open(infopath, 'rb') as f:
                 info = pickle.load(f)
         else:
             info = {


### PR DESCRIPTION
This patch is to support python3.4 and python3.5 in pqueue.
or following error will be thrown:

UnicodeDecodeError: 'utf-8' codec can't decode byte 0x80 in position 0: invalid
start byte

to reproduce it, simply run:
python3.4 runtest.py